### PR TITLE
Add wait_fold for iterating over FDs

### DIFF
--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -116,6 +116,14 @@ external caml_polly_wait :
   -> (Unix.file_descr -> Unix.file_descr -> Events.t -> unit)
   -> int (* actual number of ready fds; 0 = timeout *) = "caml_polly_wait"
 
+external caml_polly_wait_fold :
+     t (* epoll fd *)
+  -> int (* max number of fds handled *)
+  -> int (* timeout in ms *)
+  -> 'a (* initial value *)
+  -> (Unix.file_descr -> Unix.file_descr -> Events.t -> 'a -> 'a)
+  -> 'a (* final value *) = "caml_polly_wait_fold"
+
 let create = caml_polly_create1
 
 let close t = Unix.close t
@@ -127,3 +135,5 @@ let del t fd = caml_polly_del t fd Events.empty
 let upd = caml_polly_mod
 
 let wait = caml_polly_wait
+
+let wait_fold = caml_polly_wait_fold

--- a/lib/polly.mli
+++ b/lib/polly.mli
@@ -116,3 +116,16 @@ val wait :
   -> (t -> Unix.file_descr -> Events.t -> unit)
   -> int
 (** number of fds ready, 0 = timeout *)
+
+(** [wait_fold epoll max timeout init f] works similar to [wait] except that
+    function f additionally receives and produces a value of type ['a]
+    that is threaded through the invocations of [f]]; the final value
+    is returned. *)
+
+val wait_fold :
+     t (** epoll *)
+  -> int (** max fds to handle *)
+  -> int (** timeout in milliseconds: -1 = wait forever *)
+  -> 'a (* initial value passed to f below *)
+  -> (t -> Unix.file_descr -> Events.t -> 'a -> 'a)
+  -> 'a

--- a/lib/polly_stubs.c
+++ b/lib/polly_stubs.c
@@ -124,13 +124,17 @@ caml_polly_wait_fold(value val_epfd, value val_max, value val_timeout,
 		     value val_init, value val_f)
 {
 	CAMLparam5(val_epfd, val_max, val_timeout, val_init, val_f);
-	value args[4];
+	value args[4];		/* must not be CAMLlocalN */
+
+	/* see
+	 * https://github.com/ocaml/ocaml/commit/9acf32acf8843db4083c92a0200309fa51d0e4d1
+	 */
 
 	struct epoll_event *events;
 	int ready, i;
 
 	if (Int_val(val_max) <= 0)
-		uerror(__FUNCTION__, Nothing);
+		caml_invalid_argument(__FUNCTION__);
 	events =
 	    (struct epoll_event *)alloca(Int_val(val_max) *
 					 sizeof(struct epoll_event));


### PR DESCRIPTION
The current Polly.wait invokes a function f with every file descriptor that is ready to be processed. It assumes that these involcations are independent. To faciliate passing results from f back to the caller, introduce wait_fold:

  val wait_fold :
       t (** epoll *)
    -> int (** max fds to handle *)
    -> int (** timeout in milliseconds: -1 = wait forever *)
    -> 'a (* initial value passed to f below *)
    -> (t -> Unix.file_descr -> Events.t -> 'a -> 'a)
    -> 'a

Function f receives as last argument a value and returns a value of the same type, which is passed to the next invocation of f. The value of the last invocation is returned by wait_fold. The first invocation of f receives a value provided as 4th argument to wait_fold by the caller.

To avoid allocating OCaml values, wait_fold does not return the number of file descriptors that were processed. But it would be possible to implement it using wait_fold.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>