### PR TITLE
Documentation fixes and CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,67 @@
+name: Main workflow
+
+on:
+  - pull_request
+  - push
+
+permissions: read-all
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 5.0.x
+          - 4.14.x
+          - 4.08.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest
+
+  lint-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml 4.14.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.x
+          dune-cache: true
+
+      - name: Lint fmt
+        uses: ocaml/setup-ocaml/lint-fmt@v2
+
+  lint-opam:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v3
+
+      - name: Set-up OCaml 4.14
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14
+          dune-cache: true
+
+      - name: Lint opam
+        uses: ocaml/setup-ocaml/lint-opam@v2

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,4 @@
+version=0.22.4
 profile=ocamlformat
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical

--- a/lib/polly.mli
+++ b/lib/polly.mli
@@ -8,9 +8,9 @@ type t
 
 val create : unit -> t
 (** [create ()] returns an epoll(2) file descriptor which is passed
- * later to [wait], [add], [upd], and [del]. It must be passed to
- * [close] when no longer needed.
- *)
+    later to [wait], [add], [upd], and [del]. It must be passed to
+    [close] when no longer needed.
+*)
 
 val close : t -> unit
 (** [close t] closes the file descriptor underlying [t] *)
@@ -22,10 +22,10 @@ module Events : sig
   val empty : t
   (** empty set *)
 
-  (* The values below define singleton sets containing exactly one
-   * event like [inp] (input) or [hup]. See epoll_ctl(2) for the events
-   * available. Sets can be combined using [land] (intersection) and
-   * [lor] (join) and compared using [(=)].
+  (** The values below define singleton sets containing exactly one
+      event like [inp] (input) or [hup]. See epoll_ctl(2) for the events
+      available. Sets can be combined using [land] (intersection) and
+      [lor] (join) and compared using [(=)].
    *)
 
   val inp : t
@@ -70,9 +70,9 @@ module Events : sig
 
   val test : t -> t -> bool
   (** [test x y] returns true, if and only if the intersection of the
-   * two sets is not empty. The common case is [test set x] where [set]
-   * is unknown and [x] is a singleton to check that [x] is contained in
-   * [set].
+      two sets is not empty. The common case is [test set x] where [set]
+      is unknown and [x] is a singleton to check that [x] is contained in
+      [set].
    *)
 
   val to_string : t -> string
@@ -80,35 +80,33 @@ module Events : sig
 end
 
 val add : t -> Unix.file_descr -> Events.t -> unit
-(** [add epoll fd events] registers [fd] with [epoll] to monitor for
- * [events]
- *)
+(** [add epoll fd events] registers [fd] with [epoll] to monitor for [events] *)
 
 val upd : t -> Unix.file_descr -> Events.t -> unit
 (** [upd epoll fd events] updates the events set of [fd] where [fd] has
- * been previously been registered. [upd] is called [mod] in the Linux
- * documentation but [mod] is already an infix operator in OCaml. *)
+    been previously been registered. [upd] is called [mod] in the Linux
+    documentation but [mod] is already an infix operator in OCaml. *)
 
 val del : t -> Unix.file_descr -> unit
 (** [del epoll fd] unregister [fd] fro [epoll] *)
 
 (** [wait epoll max timeout f] waits for events on the fds registered
-   * with [epoll] to happen or to return after [timeout]. When fds are
-   * found to be ready, [wait] iterates over them by calling
-   * [f epoll fd events]. [f] receives [epoll], the [fd] being
-   * monitored, and the [events]. At most [max] fds are being iterated
-   * over by a call to [wait]. Note that still more than [max] fds could
-   * be ready to be processed - they would be handled by the next call
-   * to [wait].
-   *
-   * It is important to address the events that trigger an fd to be
-   * handled as otherwise the same fd will be handled again at the next
-   * call to [wait], leading to a tight loop. This is worth checking
-   * using strace(1).
-   *
-   * See the epoll_wait(2) manual page for the details of the system
-   * call.
-   *)
+    with [epoll] to happen or to return after [timeout]. When fds are
+    found to be ready, [wait] iterates over them by calling
+    [f epoll fd events]. [f] receives [epoll], the [fd] being
+    monitored, and the [events]. At most [max] fds are being iterated
+    over by a call to [wait]. Note that still more than [max] fds could
+    be ready to be processed - they would be handled by the next call
+    to [wait].
+ 
+    It is important to address the events that trigger an fd to be
+    handled as otherwise the same fd will be handled again at the next
+    call to [wait], leading to a tight loop. This is worth checking
+    using strace(1).
+ 
+    See the epoll_wait(2) manual page for the details of the system
+    call.
+*)
 val wait :
      t (** epoll *)
   -> int (** max fds to handle *)
@@ -117,11 +115,6 @@ val wait :
   -> int
 (** number of fds ready, 0 = timeout *)
 
-(** [wait_fold epoll max timeout init f] works similar to [wait] except that
-    function f additionally receives and produces a value of type ['a]
-    that is threaded through the invocations of [f]]; the final value
-    is returned. *)
-
 val wait_fold :
      t (** epoll *)
   -> int (** max fds to handle *)
@@ -129,3 +122,7 @@ val wait_fold :
   -> 'a (* initial value passed to f below *)
   -> (t -> Unix.file_descr -> Events.t -> 'a -> 'a)
   -> 'a
+(** [wait_fold epoll max timeout init f] works similar to [wait] except that
+    function f additionally receives and produces a value of type ['a]
+    that is threaded through the invocations of [f]]; the final value
+    is returned. *)


### PR DESCRIPTION
See the rendering at https://ocaml.org/p/polly/latest/doc/Polly/index.html, it has a lot of extra `*`, very likely due to an old bug in Vim's OCaml support (since fixed).

I'm not entirely happy with the rendering of '@param', but at least it shows up now, previously those doc comments were completely dropped.