### PR TITLE
untagged bindings to epoll_ctl

### DIFF
--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -146,7 +146,7 @@ let upd : t -> Unix.file_descr -> Events.t -> unit =
  fun t fd evt ->
   let __FUNCTION__ = "Polly.upd" in
   let r = caml_polly_mod t (Obj.magic fd) evt in
-   if r = -1 then uerror __FUNCTION__
+  if r = -1 then uerror __FUNCTION__
 
 let wait = caml_polly_wait
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -130,20 +130,23 @@ let close t = Unix.close (Obj.magic t : Unix.file_descr)
 
 external uerror : string -> 'a = "caml_raise_unix_error"
 
-let add : t -> Unix.file_descr -> Events.t -> unit = fun t fd evt ->
-  let __FUNCTION__ = "Polly.add" in
-  let r = caml_polly_add t (Obj.magic fd) evt in
-  if r = -1 then uerror __FUNCTION__
+let add : t -> Unix.file_descr -> Events.t -> unit =
+  fun t fd evt ->
+    let __FUNCTION__ = "Polly.add" in
+    let r = caml_polly_add t (Obj.magic fd) evt in
+    if r = -1 then uerror __FUNCTION__
 
-let del : t -> Unix.file_descr -> unit = fun t fd ->
-  let __FUNCTION__ = "Polly.del" in
-  let r = caml_polly_del t (Obj.magic fd) Events.empty in
-  if r = -1 then uerror __FUNCTION__
+let del : t -> Unix.file_descr -> unit =
+  fun t fd ->
+    let __FUNCTION__ = "Polly.del" in
+    let r = caml_polly_del t (Obj.magic fd) Events.empty in
+    if r = -1 then uerror __FUNCTION__
 
-let upd : t -> Unix.file_descr -> Events.t -> unit = fun t fd evt ->
-  let __FUNCTION__ = "Polly.upd" in
-  let r = caml_polly_mod t (Obj.magic fd) evt in
-  if r = -1 then uerror __FUNCTION__
+let upd : t -> Unix.file_descr -> Events.t -> unit =
+  fun t fd evt ->
+    let __FUNCTION__ = "Polly.upd" in
+    let r = caml_polly_mod t (Obj.magic fd) evt in
+    if r = -1 then uerror __FUNCTION__
 
 let wait = caml_polly_wait
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -98,13 +98,28 @@ end
 
 type t = int (* epoll fd *)
 
-external caml_polly_add : (t [@untagged]) -> (int [@untagged]) -> (Events.t [@untagged]) -> (int [@untagged]) [@noalloc]
+external caml_polly_add :
+  (   (t [@untagged])
+   -> (int [@untagged])
+   -> (Events.t [@untagged])
+   -> (int [@untagged])
+  [@noalloc])
   = "caml_polly_add" "caml_untagged_polly_add"
 
-external caml_polly_del : (t [@untagged]) -> (int [@untagged]) -> (Events.t [@untagged]) -> (int [@untagged]) [@noalloc]
+external caml_polly_del :
+  (   (t [@untagged])
+   -> (int [@untagged])
+   -> (Events.t [@untagged])
+   -> (int [@untagged])
+  [@noalloc])
   = "caml_polly_del" "caml_untagged_polly_del"
 
-external caml_polly_mod : (t [@untagged]) -> (int [@untagged]) -> (Events.t [@untagged]) -> (int [@untagged]) [@noalloc]
+external caml_polly_mod :
+  (   (t [@untagged])
+   -> (int [@untagged])
+   -> (Events.t [@untagged])
+   -> (int [@untagged])
+  [@noalloc])
   = "caml_polly_mod" "caml_untagged_polly_mod"
 
 external caml_polly_create1 : unit -> t = "caml_polly_create1"

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -103,24 +103,24 @@ external caml_polly_add :
    -> (int[@untagged])
    -> (Events.t[@untagged])
    -> (int[@untagged])
-  [@noalloc])
-  = "caml_polly_add" "caml_untagged_polly_add"
+  [@noalloc]
+  ) = "caml_polly_add" "caml_untagged_polly_add"
 
 external caml_polly_del :
   (   (t[@untagged])
    -> (int[@untagged])
    -> (Events.t[@untagged])
    -> (int[@untagged])
-  [@noalloc])
-  = "caml_polly_del" "caml_untagged_polly_del"
+  [@noalloc]
+  ) = "caml_polly_del" "caml_untagged_polly_del"
 
 external caml_polly_mod :
   (   (t[@untagged])
    -> (int[@untagged])
    -> (Events.t[@untagged])
    -> (int[@untagged])
-  [@noalloc])
-  = "caml_polly_mod" "caml_untagged_polly_mod"
+  [@noalloc]
+  ) = "caml_polly_mod" "caml_untagged_polly_mod"
 
 external caml_polly_create1 : unit -> t = "caml_polly_create1"
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -128,22 +128,22 @@ let create = caml_polly_create1
 
 let close t = Unix.close (Obj.magic t : Unix.file_descr)
 
-external uerror : string -> 'a -> 'b = "caml_uerror"
+external uerror : string -> 'a = "caml_raise_unix_error"
 
 let add : t -> Unix.file_descr -> Events.t -> unit = fun t fd evt ->
   let __FUNCTION__ = "Polly.add" in
   let r = caml_polly_add t (Obj.magic fd) evt in
-  if r = -1 then uerror __FUNCTION__ None
+  if r = -1 then uerror __FUNCTION__
 
 let del : t -> Unix.file_descr -> unit = fun t fd ->
   let __FUNCTION__ = "Polly.del" in
   let r = caml_polly_del t (Obj.magic fd) Events.empty in
-  if r = -1 then uerror __FUNCTION__ None
+  if r = -1 then uerror __FUNCTION__
 
 let upd : t -> Unix.file_descr -> Events.t -> unit = fun t fd evt ->
   let __FUNCTION__ = "Polly.upd" in
   let r = caml_polly_mod t (Obj.magic fd) evt in
-  if r = -1 then uerror __FUNCTION__ None
+  if r = -1 then uerror __FUNCTION__
 
 let wait = caml_polly_wait
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -99,26 +99,26 @@ end
 type t = int (* epoll fd *)
 
 external caml_polly_add :
-  (   (t [@untagged])
-   -> (int [@untagged])
-   -> (Events.t [@untagged])
-   -> (int [@untagged])
+  (   (t[@untagged])
+   -> (int[@untagged])
+   -> (Events.t[@untagged])
+   -> (int[@untagged])
   [@noalloc])
   = "caml_polly_add" "caml_untagged_polly_add"
 
 external caml_polly_del :
-  (   (t [@untagged])
-   -> (int [@untagged])
-   -> (Events.t [@untagged])
-   -> (int [@untagged])
+  (   (t[@untagged])
+   -> (int[@untagged])
+   -> (Events.t[@untagged])
+   -> (int[@untagged])
   [@noalloc])
   = "caml_polly_del" "caml_untagged_polly_del"
 
 external caml_polly_mod :
-  (   (t [@untagged])
-   -> (int [@untagged])
-   -> (Events.t [@untagged])
-   -> (int [@untagged])
+  (   (t[@untagged])
+   -> (int[@untagged])
+   -> (Events.t[@untagged])
+   -> (int[@untagged])
   [@noalloc])
   = "caml_polly_mod" "caml_untagged_polly_mod"
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -131,22 +131,22 @@ let close t = Unix.close (Obj.magic t : Unix.file_descr)
 external uerror : string -> 'a = "caml_raise_unix_error"
 
 let add : t -> Unix.file_descr -> Events.t -> unit =
-  fun t fd evt ->
-    let __FUNCTION__ = "Polly.add" in
-    let r = caml_polly_add t (Obj.magic fd) evt in
-    if r = -1 then uerror __FUNCTION__
+ fun t fd evt ->
+  let __FUNCTION__ = "Polly.add" in
+  let r = caml_polly_add t (Obj.magic fd) evt in
+  if r = -1 then uerror __FUNCTION__
 
 let del : t -> Unix.file_descr -> unit =
-  fun t fd ->
-    let __FUNCTION__ = "Polly.del" in
-    let r = caml_polly_del t (Obj.magic fd) Events.empty in
-    if r = -1 then uerror __FUNCTION__
+ fun t fd ->
+  let __FUNCTION__ = "Polly.del" in
+  let r = caml_polly_del t (Obj.magic fd) Events.empty in
+  if r = -1 then uerror __FUNCTION__
 
 let upd : t -> Unix.file_descr -> Events.t -> unit =
-  fun t fd evt ->
-    let __FUNCTION__ = "Polly.upd" in
-    let r = caml_polly_mod t (Obj.magic fd) evt in
-    if r = -1 then uerror __FUNCTION__
+ fun t fd evt ->
+  let __FUNCTION__ = "Polly.upd" in
+  let r = caml_polly_mod t (Obj.magic fd) evt in
+   if r = -1 then uerror __FUNCTION__
 
 let wait = caml_polly_wait
 

--- a/lib/polly_stubs.c
+++ b/lib/polly_stubs.c
@@ -43,6 +43,13 @@ CONSTANT(EPOLLET);
 CONSTANT(EPOLLEXCLUSIVE);
 #endif
 
+/* necessary because of changes from 4.X to 5.X in ocaml,
+   uerror is a macro in 5.0 */
+CAMLprim void caml_raise_unix_error(value funname) {
+  CAMLparam1(funname);
+  uerror(String_val(funname),Nothing);
+}
+
 CAMLprim value caml_polly_create1(value val_unit)
 {
 	CAMLparam1(val_unit);

--- a/lib/polly_stubs.c
+++ b/lib/polly_stubs.c
@@ -60,16 +60,13 @@ CAMLprim value caml_polly_create1(value val_unit)
 static value
 caml_polly_ctl(value val_epfd, value val_fd, value val_events, int op)
 {
-	CAMLparam3(val_epfd, val_fd, val_events);
-	struct epoll_event event = {
-		.events = (uint32_t) Int_val(val_events),
-		.data.fd = Int_val(val_fd)
-	};
+  CAMLparam0(); /* no need to register int */
+  struct epoll_event event = {
+    .events = (uint32_t) Int_val(val_events),
+    .data.fd = Int_val(val_fd)
+  };
 
-	if (epoll_ctl(Int_val(val_epfd), op, Int_val(val_fd), &event) == -1)
-		uerror(__FUNCTION__, Nothing);
-
-	CAMLreturn(Val_unit);
+  CAMLreturn(Val_int(epoll_ctl(Int_val(val_epfd), op, Int_val(val_fd), &event)));
 }
 
 CAMLprim value caml_polly_add(value val_epfd, value val_fd, value val_events)
@@ -77,14 +74,38 @@ CAMLprim value caml_polly_add(value val_epfd, value val_fd, value val_events)
 	return caml_polly_ctl(val_epfd, val_fd, val_events, EPOLL_CTL_ADD);
 }
 
+int caml_untagged_polly_add(int epfd, int fd, int events) {
+  struct epoll_event event = {
+    .events = (uint32_t) events,
+    .data.fd = fd
+  };
+  return epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
+}
+
 CAMLprim value caml_polly_mod(value val_epfd, value val_fd, value val_events)
 {
 	return caml_polly_ctl(val_epfd, val_fd, val_events, EPOLL_CTL_MOD);
 }
 
+int caml_untagged_polly_mod(int epfd, int fd, int events) {
+  struct epoll_event event = {
+    .events = (uint32_t) events,
+    .data.fd = fd
+  };
+  return epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &event);
+}
+
 CAMLprim value caml_polly_del(value val_epfd, value val_fd, value val_events)
 {
 	return caml_polly_ctl(val_epfd, val_fd, val_events, EPOLL_CTL_DEL);
+}
+
+int caml_untagged_polly_del(int epfd, int fd, int events) {
+  struct epoll_event event = {
+    .events = (uint32_t) events,
+    .data.fd = fd
+  };
+  return epoll_ctl(epfd, EPOLL_CTL_DEL, fd, &event);
 }
 
 CAMLprim value


### PR DESCRIPTION
This is usefull when you frequently change the epoll list (which is not the case in general if you use ET and non blocking socket, because you can wait for both in and out all the time and only have to setup the epoll control when initializing the socket).

There is one problem: we know on linux that file_descr are int ... but to untag it we need a dirty Obj.magic.