### PR TITLE
Wait buffer

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,3 +5,12 @@
  (foreign_stubs
   (language c)
   (names polly_stubs)))
+
+(rule
+ (targets constants.ml)
+ (deps
+  (:bin ../src/constants.exe))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{bin}))))

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -1,7 +1,7 @@
 module Events = struct
   type t = int
 
-  include Constants.Epoll_constants
+  include Constants.Epoll
 
   let empty = 0
 
@@ -87,7 +87,7 @@ module EventFD = struct
 
   external create : int -> flags -> t = "caml_polly_eventfd"
 
-  include Constants.EventFd_constants
+  include Constants.EventFD
 
   let empty = 0
 

--- a/lib/polly.ml
+++ b/lib/polly.ml
@@ -1,65 +1,7 @@
 module Events = struct
   type t = int
 
-  external polly_IN : unit -> t = "caml_polly_EPOLLIN"
-
-  external polly_PRI : unit -> t = "caml_polly_EPOLLPRI"
-
-  external polly_OUT : unit -> t = "caml_polly_EPOLLOUT"
-
-  external polly_RDNORM : unit -> t = "caml_polly_EPOLLRDNORM"
-
-  external polly_RDBAND : unit -> t = "caml_polly_EPOLLRDBAND"
-
-  external polly_WRNORM : unit -> t = "caml_polly_EPOLLWRNORM"
-
-  external polly_WRBAND : unit -> t = "caml_polly_EPOLLWRBAND"
-
-  external polly_MSG : unit -> t = "caml_polly_EPOLLMSG"
-
-  external polly_ERR : unit -> t = "caml_polly_EPOLLERR"
-
-  external polly_HUP : unit -> t = "caml_polly_EPOLLHUP"
-
-  external polly_RDHUP : unit -> t = "caml_polly_EPOLLRDHUP"
-
-  external polly_WAKEUP : unit -> t = "caml_polly_EPOLLWAKEUP"
-
-  external polly_ONESHOT : unit -> t = "caml_polly_EPOLLONESHOT"
-
-  external polly_ET : unit -> t = "caml_polly_EPOLLET"
-
-  (* external polly_EXCLUSIVE : unit -> t = "caml_polly_EPOLLEXCLUSIVE" *)
-
-  let inp = polly_IN ()
-
-  let pri = polly_PRI ()
-
-  let out = polly_OUT ()
-
-  let rdnorm = polly_RDNORM ()
-
-  let rdband = polly_RDBAND ()
-
-  let wrnorm = polly_WRNORM ()
-
-  let wrband = polly_WRBAND ()
-
-  let msg = polly_MSG ()
-
-  let err = polly_ERR ()
-
-  let hup = polly_HUP ()
-
-  let rdhup = polly_RDHUP ()
-
-  let wakeup = polly_WAKEUP ()
-
-  let oneshot = polly_ONESHOT ()
-
-  let et = polly_ET ()
-
-  (* let exclusive = polly_EXCLUSIVE () *)
+  include Constants.Epoll_constants
 
   let empty = 0
 
@@ -145,17 +87,7 @@ module EventFD = struct
 
   external create : int -> flags -> t = "caml_polly_eventfd"
 
-  external efd_cloexec : unit -> flags = "caml_polly_EFD_CLOEXEC"
-
-  external efd_nonblock : unit -> flags = "caml_polly_EFD_NONBLOCK"
-
-  external efd_semaphore : unit -> flags = "caml_polly_EFD_SEMAPHORE"
-
-  let cloexec : flags = efd_cloexec ()
-
-  let nonblock : flags = efd_nonblock ()
-
-  let semaphore : flags = efd_semaphore ()
+  include Constants.EventFd_constants
 
   let empty = 0
 

--- a/lib/polly.mli
+++ b/lib/polly.mli
@@ -79,6 +79,13 @@ module Events : sig
   (** [to_string t] return a string representation of [t] for debugging *)
 end
 
+module EventBuffer : sig
+  type t
+
+  val create : int -> t
+  (** create a buffer to hold events ready for opearations *)
+end
+
 val add : t -> Unix.file_descr -> Events.t -> unit
 (** [add epoll fd events] registers [fd] with [epoll] to monitor for [events] *)
 
@@ -115,6 +122,11 @@ val wait : t -> int -> int -> (t -> Unix.file_descr -> Events.t -> unit) -> int
     @returns number of fds ready, 0 = timeout
 *)
 
+val wait_buffer :
+  t -> EventBuffer.t -> int -> (t -> Unix.file_descr -> Events.t -> unit) -> int
+(** [wait_buf epoll buf timeout f] same as [wait epoll max timeout f], but takes a
+   buffer preallocated buffer created with [EventBuffer.make max]. *)
+
 val wait_fold :
   t -> int -> int -> 'a -> (t -> Unix.file_descr -> Events.t -> 'a -> 'a) -> 'a
 (** [wait_fold epoll max timeout init f] works similar to [wait] except that
@@ -129,6 +141,15 @@ val wait_fold :
     @param f callback
     @returns number of fds ready, 0 = timeout
 *)
+
+val wait_buffer_fold :
+     t
+  -> EventBuffer.t
+  -> int
+  -> 'a
+  -> (t -> Unix.file_descr -> Events.t -> 'a -> 'a)
+  -> 'a
+(** same as [wait_buffer], but for [wait_fold]*)
 
 module EventFD : sig
   (** This module provides an interface to the eventfd(2) system call *)

--- a/lib/polly_stubs.c
+++ b/lib/polly_stubs.c
@@ -18,30 +18,8 @@
 #define LOCATION __FILE__ ":" S2(__LINE__)
 
 /* Make all constants available to clients by exporting them via a
- * function. This avoids having to hard code them on the client side. 
+ * function. This avoids having to hard code them on the client side.
  * */
-
-#define CONSTANT(name) \
-  CAMLprim value caml_polly_ ## name(value unit) { return Val_int(name); }
-
-CONSTANT(EPOLLIN);
-CONSTANT(EPOLLPRI);
-CONSTANT(EPOLLOUT);
-CONSTANT(EPOLLRDNORM);
-CONSTANT(EPOLLRDBAND);
-CONSTANT(EPOLLWRNORM);
-CONSTANT(EPOLLWRBAND);
-CONSTANT(EPOLLMSG);
-CONSTANT(EPOLLERR);
-CONSTANT(EPOLLHUP);
-CONSTANT(EPOLLRDHUP);
-CONSTANT(EPOLLWAKEUP);
-CONSTANT(EPOLLONESHOT);
-CONSTANT(EPOLLET);
-
-#if 0
-CONSTANT(EPOLLEXCLUSIVE);
-#endif
 
 CAMLprim value caml_polly_create1(value val_unit)
 {
@@ -166,8 +144,6 @@ CAMLprim value caml_polly_eventfd(value initval, value flags)
 	CAMLreturn(Val_int(sock));
 }
 
-CONSTANT(EFD_CLOEXEC);
-CONSTANT(EFD_NONBLOCK);
-CONSTANT(EFD_SEMAPHORE);
+
 
 /* vim: set ts=8 noet: */

--- a/src/constants.c
+++ b/src/constants.c
@@ -1,0 +1,40 @@
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void constant(const char* name, int value) {
+  printf("  let %s = 0x%x\n", name, value);
+}
+
+int main(int argc, char **argv) {
+  printf("module Epoll_constants = struct\n");
+
+  constant("inp",EPOLLIN);
+  constant("pri",EPOLLPRI);
+  constant("out",EPOLLOUT);
+  constant("rdnorm",EPOLLRDNORM);
+  constant("rdband",EPOLLRDBAND);
+  constant("wrnorm",EPOLLWRNORM);
+  constant("wrband",EPOLLWRBAND);
+  constant("msg",EPOLLMSG);
+  constant("err",EPOLLERR);
+  constant("hup",EPOLLHUP);
+  constant("rdhup",EPOLLRDHUP);
+  constant("wakeup",EPOLLWAKEUP);
+  constant("oneshot",EPOLLONESHOT);
+  constant("et",EPOLLET);
+  //constant("exclusive",EPOLLEXCLUSIVE);
+
+  printf("end\n");
+
+  printf("module EventFd_constants = struct\n");
+
+  constant("cloexec", EFD_CLOEXEC);
+  constant("nonblock", EFD_NONBLOCK);
+  constant("semaphore", EFD_SEMAPHORE);
+
+  printf("end\n");
+
+  fflush(stdout);
+}

--- a/src/constants.c
+++ b/src/constants.c
@@ -28,6 +28,8 @@ int main(int argc, char **argv) {
 
   printf("end\n");
 
+  printf("let epoll_event_size = %d\n", sizeof(sizeof(struct epoll_event)));
+
   printf("module EventFD = struct\n");
 
   constant("cloexec", EFD_CLOEXEC);

--- a/src/constants.c
+++ b/src/constants.c
@@ -8,7 +8,7 @@ void constant(const char* name, int value) {
 }
 
 int main(int argc, char **argv) {
-  printf("module Epoll_constants = struct\n");
+  printf("module Epoll = struct\n");
 
   constant("inp",EPOLLIN);
   constant("pri",EPOLLPRI);
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
 
   printf("end\n");
 
-  printf("module EventFd_constants = struct\n");
+  printf("module EventFD = struct\n");
 
   constant("cloexec", EFD_CLOEXEC);
   constant("nonblock", EFD_NONBLOCK);
@@ -36,5 +36,5 @@ int main(int argc, char **argv) {
 
   printf("end\n");
 
-  fflush(stdout);
+  return 0;
 }

--- a/src/dune
+++ b/src/dune
@@ -2,3 +2,9 @@
  (name main)
  (public_name "polly-test")
  (libraries cmdliner polly))
+
+(rule
+ (targets constants.exe)
+ (deps constants.c)
+ (action
+  (run gcc -o %{targets} %{deps})))


### PR DESCRIPTION
Introduces EventBuffer to avoid allocating at each wait/wait_fold.

Warning: This PR is based on constant3 (PR#10) and not master, because I added one line in src/constants.ml

Questions: 
- I think the new wait_buffer/wait_buffer_fold could replace wait and wait_fold which do not have the intended complexity. We could use deprecation or just accept a breaking change ? Problem with deprecation is we need new function names.
- I am not sure if I want `EventBuffer.t = int * Bytes.t` or just `Bytes.t` and to a division to compute val_max ?