### PR TITLE
fix(eventfd): raise exception on error

### DIFF
--- a/lib/polly_stubs.c
+++ b/lib/polly_stubs.c
@@ -141,6 +141,8 @@ CAMLprim value caml_polly_eventfd(value initval, value flags)
 {
 	CAMLparam0();
 	int sock = eventfd(Int_val(initval), Int_val(flags));
+	if (-1 == sock)
+		uerror(__FUNCTION__, Nothing);
 	CAMLreturn(Val_int(sock));
 }
 


### PR DESCRIPTION
`eventfd` may fail (e.g. if you are out of file descriptors). This needs to be handled the same way that an `epoll_create` failure is.

I put the constant to be compared first to detect typos (otherwise a typo of `=` would cause `-1` to be assigned to `sock`,whereas `-1 == sock` is safer: typos become compile errors because `-1 = sock` is not valid).

Fixes: 4150f12 ("Add eventfd (#4)")

Note: the function uses `CAMLparam0` but takes 2 `value` as parameters. Strictly that doesn't match what the manual says it should do, but the 2 parameters are integers, so they wouldn't be registered with the GC anyway, so this is probably fine.