### PR TITLE
Fix documentation of Polly.wait and Polly.EventFD.test

### DIFF
--- a/lib/polly.mli
+++ b/lib/polly.mli
@@ -157,9 +157,9 @@ module EventFD : sig
 
   val test : flags -> flags -> bool
   (** [test x y] returns true, if and only if the intersection of the
-   * two sets is not empty. The common case is [test set x] where [set]
-   * is unknown and [x] is a singleton to check that [x] is contained in
-   * [set].
+     two sets is not empty. The common case is [test set x] where [set]
+     is unknown and [x] is a singleton to check that [x] is contained in
+     [set].
    *)
 
   val ( lor ) : flags -> flags -> flags

--- a/lib/polly.mli
+++ b/lib/polly.mli
@@ -110,7 +110,7 @@ val wait : t -> int -> int -> (t -> Unix.file_descr -> Events.t -> unit) -> int
 
     @param epoll epoll
     @param max max fds to handle
-    @param init initial value passed to [f] below
+    @param timeout timeout in milliseconds: -1 = wait forever
     @param f callback
     @returns number of fds ready, 0 = timeout
 *)


### PR DESCRIPTION
It is important to know that the timeout is in milliseconds.